### PR TITLE
Hotfix for typo and logging 

### DIFF
--- a/src/.env
+++ b/src/.env
@@ -1,6 +1,11 @@
 # Uncomment any of the variables below to customize your enviornment
 
-#SERVER_ADDR=
-#REDIS_ADDR=
 #POSTGRES_ADDR=
-CORS_ALLOWED_METHODS="GET OPTIONS"
+#REDIS_ADDR=
+#SERVER_ADDR=
+#SSE_UPDATE_INTERVAL=
+#WS_UPDATE_INTERVAL=
+#REDIS_POLL_INTERVAL=
+
+#Possible values for the log level are eror, warn, info, debug, trace
+RUST_LOG=warn

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use log::{log_enabled, Level};
 use ragequit::{
     any_of, config,
     parse_client_request::{sse, user, ws},
@@ -11,6 +12,10 @@ fn main() {
     config::logging_and_env();
     let client_agent_sse = ClientAgent::blank();
     let client_agent_ws = client_agent_sse.clone_with_shared_receiver();
+
+    if log_enabled!(Level::Warn) {
+        println!("Streaming server initialized and ready to accept connections");
+    };
 
     // Server Sent Events
     //

--- a/src/parse_client_request/user/postgres.rs
+++ b/src/parse_client_request/user/postgres.rs
@@ -3,6 +3,7 @@ use crate::config;
 
 pub fn query_for_user_data(access_token: &str) -> (i64, Option<Vec<String>>, Vec<String>) {
     let conn = config::postgres();
+
     let query_result = conn
             .query(
                 "

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -1,5 +1,5 @@
 //! Provides an interface between the `Warp` filters and the underlying
-//! mechanics of talking with Redis/managing multiple threads.  
+//! mechanics of talking with Redis/managing multiple threads.
 //!
 //! The `ClientAgent`'s interface is very simple.  All you can do with it is:
 //!  * Create a totally new `ClientAgent` with no shared data;


### PR DESCRIPTION
This fixes a typo that was erroneously checking for an env variable named `POSTGRESS_ADDR` (with two s's) rather than `POSTGRES_ADDR`.

It also adds some logging of the postgres connection and of the initial status of the server and sets the default log level to `warn` instead of `debug` so that these log messages display by default.